### PR TITLE
Add minimal CLI Tarot app with sample deck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # TAORT_APP_1
 
-This repository houses the Tarot App blueprint and future implementation.
+This repository now includes a minimal command-line Tarot app.
+
+## Usage
+
+Create a virtual environment and install dependencies (none required for the MVP). Run the app:
+
+```
+python -m tarot_app.cli
+```
+
+You will be prompted to draw a card and receive a brief summary, actions, and mantra.
+
+## Development
+
+Run tests with:
+
+```
+pytest
+```
 
 For detailed product, UX, and technical plans, see [TAROT_APP_BLUEPRINT.md](TAROT_APP_BLUEPRINT.md).

--- a/deck_rws.json
+++ b/deck_rws.json
@@ -1,0 +1,33 @@
+{
+  "Strength": {
+    "upright": ["inner resilience", "gentle power", "self-regulation"],
+    "reversed": ["self-doubt", "forcefulness", "fatigue"],
+    "summary": "Courage through gentle self-control; choose a small boundary now.",
+    "actions": [
+      "Write your key need in 1 sentence.",
+      "Pick a time to speak.",
+      "Practice a 4-4-6 breath before the chat."
+    ],
+    "mantra": "Calm is my strength."
+  },
+  "The Fool": {
+    "upright": ["new beginnings", "innocence", "free spirit"],
+    "reversed": ["recklessness", "hesitation", "naivety"],
+    "summary": "Step forward, but watch your footing.",
+    "actions": [
+      "Name one step that feels daring.",
+      "Set a small safety net."
+    ],
+    "mantra": "I leap with awareness."
+  },
+  "The Magician": {
+    "upright": ["manifestation", "resourcefulness", "power"],
+    "reversed": ["manipulation", "untapped talents", "scattered energy"],
+    "summary": "Your tools are ready; focus your intent.",
+    "actions": [
+      "Gather your resources.",
+      "Commit to one clear goal today."
+    ],
+    "mantra": "I create with focus."
+  }
+}

--- a/tarot_app/__init__.py
+++ b/tarot_app/__init__.py
@@ -1,0 +1,2 @@
+"""Simple Tarot app package."""
+

--- a/tarot_app/cli.py
+++ b/tarot_app/cli.py
@@ -1,0 +1,24 @@
+import os
+from .deck import Deck
+
+
+def main() -> None:
+    deck_path = os.path.join(os.path.dirname(__file__), "..", "deck_rws.json")
+    deck_path = os.path.abspath(deck_path)
+    deck = Deck.from_json(deck_path)
+    input("When you're ready, press Enter to draw a card...")
+    card = deck.draw()
+    print(f"You drew {card['name']} ({card['orientation']}).")
+    print("Keywords:", ", ".join(card["keywords"]))
+    if card["summary"]:
+        print("Summary:", card["summary"])
+    if card["actions"]:
+        print("Actions:")
+        for action in card["actions"]:
+            print("-", action)
+    if card["mantra"]:
+        print("Mantra:", card["mantra"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tarot_app/deck.py
+++ b/tarot_app/deck.py
@@ -1,0 +1,30 @@
+import json
+import random
+from typing import Any, Dict
+
+
+class Deck:
+    """Load and draw cards from a Tarot deck."""
+
+    def __init__(self, cards: Dict[str, Dict[str, Any]]):
+        self.cards = cards
+
+    @classmethod
+    def from_json(cls, path: str) -> "Deck":
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(data)
+
+    def draw(self) -> Dict[str, Any]:
+        """Draw a random card with orientation and details."""
+        name = random.choice(list(self.cards.keys()))
+        orientation = random.choice(["upright", "reversed"])
+        card_data = self.cards[name]
+        return {
+            "name": name,
+            "orientation": orientation,
+            "keywords": card_data[orientation],
+            "summary": card_data.get("summary", ""),
+            "actions": card_data.get("actions", []),
+            "mantra": card_data.get("mantra", ""),
+        }

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tarot_app.deck import Deck
+
+
+def test_draw_returns_card():
+    deck_path = os.path.join(os.path.dirname(__file__), "..", "deck_rws.json")
+    deck_path = os.path.abspath(deck_path)
+    deck = Deck.from_json(deck_path)
+    card = deck.draw()
+    assert card["name"] in deck.cards
+    assert card["orientation"] in ("upright", "reversed")
+    assert isinstance(card["keywords"], list)


### PR DESCRIPTION
## Summary
- implement `Deck` class to load card data and draw random card
- provide simple CLI entrypoint for one-card readings
- include sample Rider–Waite deck slice and basic tests

## Testing
- `pytest`
- `python -m tarot_app.cli`

------
https://chatgpt.com/codex/tasks/task_e_6898d60f00548330ba5815a7b6c7a7fa